### PR TITLE
Add tests for TimeController and InfoPanel postRender behavior

### DIFF
--- a/src/components/HUD/__tests__/InfoPanel.test.tsx
+++ b/src/components/HUD/__tests__/InfoPanel.test.tsx
@@ -1,14 +1,62 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { InfoPanel } from "../InfoPanel";
 
+type PostRenderCallback = () => void;
+
+interface ViewerMock {
+  scene: {
+    postRender: {
+      addEventListener: ReturnType<typeof vi.fn>;
+    };
+  };
+  camera: {
+    positionCartographic: {
+      latitude: number;
+      longitude: number;
+      height: number;
+    };
+  };
+}
+
+const state: { viewer: ViewerMock | undefined } = { viewer: undefined };
+let postRenderCallback: PostRenderCallback | undefined;
+let removeListener: ReturnType<typeof vi.fn>;
+
+function degToRad(deg: number): number {
+  return (deg * Math.PI) / 180;
+}
+
+function createViewerMock(): ViewerMock {
+  return {
+    scene: {
+      postRender: {
+        addEventListener: vi.fn((cb: PostRenderCallback) => {
+          postRenderCallback = cb;
+          return removeListener;
+        }),
+      },
+    },
+    camera: {
+      positionCartographic: {
+        latitude: degToRad(0),
+        longitude: degToRad(0),
+        height: 0,
+      },
+    },
+  };
+}
+
 vi.mock("resium", () => ({
-  useCesium: () => ({ viewer: undefined }),
+  useCesium: () => ({ viewer: state.viewer }),
 }));
 
 describe("InfoPanel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    postRenderCallback = undefined;
+    removeListener = vi.fn();
+    state.viewer = undefined;
   });
 
   it("renders mode buttons with correct pressed state", () => {
@@ -87,5 +135,61 @@ describe("InfoPanel", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Night Shade" }));
     expect(onNightShadeToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("viewer があるとき postRender リスナーを登録する", () => {
+    state.viewer = createViewerMock();
+
+    render(
+      <InfoPanel
+        orbitRenderMode="geodesic"
+        onOrbitRenderModeChange={vi.fn()}
+        showNightShade={false}
+        onNightShadeToggle={vi.fn()}
+      />
+    );
+
+    expect(state.viewer.scene.postRender.addEventListener).toHaveBeenCalledTimes(1);
+  });
+
+  it("postRender コールバックでカメラ座標表示を更新する", () => {
+    state.viewer = createViewerMock();
+
+    render(
+      <InfoPanel
+        orbitRenderMode="geodesic"
+        onOrbitRenderModeChange={vi.fn()}
+        showNightShade={false}
+        onNightShadeToggle={vi.fn()}
+      />
+    );
+
+    state.viewer.camera.positionCartographic.latitude = degToRad(35.6895);
+    state.viewer.camera.positionCartographic.longitude = degToRad(139.7001);
+    state.viewer.camera.positionCartographic.height = 12_345;
+
+    act(() => {
+      postRenderCallback?.();
+    });
+
+    expect(screen.getByText("緯度: 35.6895°")).toBeInTheDocument();
+    expect(screen.getByText("経度: 139.7001°")).toBeInTheDocument();
+    expect(screen.getByText("高度: 12.3 km")).toBeInTheDocument();
+  });
+
+  it("unmount 時に postRender リスナーを解除する", () => {
+    state.viewer = createViewerMock();
+
+    const { unmount } = render(
+      <InfoPanel
+        orbitRenderMode="geodesic"
+        onOrbitRenderModeChange={vi.fn()}
+        showNightShade={false}
+        onNightShadeToggle={vi.fn()}
+      />
+    );
+
+    unmount();
+    expect(removeListener).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/TimeController/__tests__/TimeController.test.tsx
+++ b/src/components/TimeController/__tests__/TimeController.test.tsx
@@ -1,0 +1,155 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { ClockRange, JulianDate } from "cesium";
+import { TimeController } from "../TimeController";
+
+type PostRenderCallback = () => void;
+
+interface ViewerMock {
+  clock: {
+    startTime: JulianDate | undefined;
+    stopTime: JulianDate | undefined;
+    currentTime: JulianDate;
+    clockRange: ClockRange | undefined;
+    multiplier: number;
+    shouldAnimate: boolean;
+  };
+  scene: {
+    postRender: {
+      addEventListener: ReturnType<typeof vi.fn>;
+    };
+  };
+}
+
+const DAY_MS = 86_400_000;
+const WINDOW_MS = 4 * 3_600_000;
+const FIXED_NOW_MS = Date.UTC(2026, 1, 23, 10, 30, 15);
+
+const state: { viewer: ViewerMock | undefined } = { viewer: undefined };
+let postRenderCallback: PostRenderCallback | undefined;
+let removeListener: ReturnType<typeof vi.fn>;
+let dateNowSpy: ReturnType<typeof vi.spyOn>;
+
+function getWindowStartMs(ms: number): number {
+  return Math.floor(ms / WINDOW_MS) * WINDOW_MS;
+}
+
+function createViewerMock(): ViewerMock {
+  return {
+    clock: {
+      startTime: undefined,
+      stopTime: undefined,
+      currentTime: JulianDate.fromDate(new Date(0)),
+      clockRange: undefined,
+      multiplier: 1,
+      shouldAnimate: false,
+    },
+    scene: {
+      postRender: {
+        addEventListener: vi.fn((cb: PostRenderCallback) => {
+          postRenderCallback = cb;
+          return removeListener;
+        }),
+      },
+    },
+  };
+}
+
+vi.mock("resium", () => ({
+  useCesium: () => ({ viewer: state.viewer }),
+}));
+
+describe("TimeController", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(FIXED_NOW_MS);
+    postRenderCallback = undefined;
+    removeListener = vi.fn();
+    state.viewer = createViewerMock();
+  });
+
+  afterEach(() => {
+    dateNowSpy.mockRestore();
+    state.viewer = undefined;
+  });
+
+  it("初期化時に clock を設定し、現在の4時間窓開始で onDayChange を呼ぶ", () => {
+    const onDayChange = vi.fn();
+    render(<TimeController onDayChange={onDayChange} />);
+
+    const nowMs = Date.now();
+    const expectedMinMs = nowMs - 14 * DAY_MS;
+    const expectedMaxMs = nowMs + 14 * DAY_MS;
+    const expectedWindowStartMs = getWindowStartMs(nowMs);
+
+    expect(JulianDate.toDate(state.viewer!.clock.startTime!).getTime()).toBe(expectedMinMs);
+    expect(JulianDate.toDate(state.viewer!.clock.stopTime!).getTime()).toBe(expectedMaxMs);
+    expect(JulianDate.toDate(state.viewer!.clock.currentTime).getTime()).toBe(nowMs);
+    expect(state.viewer!.clock.clockRange).toBe(ClockRange.LOOP_STOP);
+    expect(state.viewer!.clock.multiplier).toBe(60);
+    expect(state.viewer!.clock.shouldAnimate).toBe(true);
+    expect(onDayChange).toHaveBeenCalledTimes(1);
+    expect(onDayChange).toHaveBeenCalledWith(expectedWindowStartMs);
+  });
+
+  it("postRender で4時間窓を跨いだとき onDayChange を呼ぶ", () => {
+    const onDayChange = vi.fn();
+    render(<TimeController onDayChange={onDayChange} />);
+
+    expect(postRenderCallback).toBeTypeOf("function");
+    onDayChange.mockClear();
+
+    const nowMs = Date.now();
+    const currentWindowStart = getWindowStartMs(nowMs);
+    const nextWindowStart = currentWindowStart + WINDOW_MS;
+
+    state.viewer!.clock.currentTime = JulianDate.fromDate(new Date(nextWindowStart + 10_000));
+
+    act(() => {
+      postRenderCallback?.();
+    });
+
+    expect(onDayChange).toHaveBeenCalledTimes(1);
+    expect(onDayChange).toHaveBeenCalledWith(nextWindowStart);
+  });
+
+  it("aoiDrawing の開始/終了で shouldAnimate を一時停止し、元の状態へ復元する", () => {
+    const onDayChange = vi.fn();
+    const { rerender } = render(<TimeController onDayChange={onDayChange} aoiDrawing={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "一時停止" }));
+    expect(state.viewer!.clock.shouldAnimate).toBe(false);
+    expect(screen.getByRole("button", { name: "再生" })).toBeInTheDocument();
+
+    rerender(<TimeController onDayChange={onDayChange} aoiDrawing={true} />);
+    expect(state.viewer!.clock.shouldAnimate).toBe(false);
+    expect(screen.getByRole("button", { name: "再生" })).toBeInTheDocument();
+
+    rerender(<TimeController onDayChange={onDayChange} aoiDrawing={false} />);
+    expect(state.viewer!.clock.shouldAnimate).toBe(false);
+    expect(screen.getByRole("button", { name: "再生" })).toBeInTheDocument();
+  });
+
+  it("seek/play/速度変更を viewer.clock に同期する", () => {
+    render(<TimeController onDayChange={vi.fn()} />);
+
+    const seekTargetMs = Date.now() + 90_000;
+    fireEvent.change(screen.getByRole("slider", { name: "タイムスライダー" }), {
+      target: { value: String(seekTargetMs) },
+    });
+    expect(JulianDate.toDate(state.viewer!.clock.currentTime).getTime()).toBe(seekTargetMs);
+
+    fireEvent.click(screen.getByRole("button", { name: "一時停止" }));
+    expect(state.viewer!.clock.shouldAnimate).toBe(false);
+
+    fireEvent.click(screen.getByText("×300"));
+    expect(state.viewer!.clock.multiplier).toBe(300);
+  });
+
+  it("unmount 時に postRender リスナーを解除する", () => {
+    const { unmount } = render(<TimeController onDayChange={vi.fn()} />);
+    unmount();
+
+    expect(removeListener).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add dedicated tests for TimeController clock/postRender lifecycle
- add tests for AOI pause/resume restoration and clock sync interactions (seek/play/multiplier)
- extend InfoPanel tests with postRender camera position updates and listener cleanup

## Testing
- npx vitest run --cache=false src/components/TimeController/__tests__/TimeController.test.tsx src/components/HUD/__tests__/InfoPanel.test.tsx

Closes #7